### PR TITLE
preventing tests from actually sending emails

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = false
   config.action_mailer.smtp_settings = {
     address:              'smtp.gmail.com',
     port:                 587,


### PR DESCRIPTION
@michael-emil-fayez   I believe this makes more sense during running tests.  emails should not actually be sent